### PR TITLE
[autobacklog] --dangerously-skip-permissions hardcoded on every Claude invocation

### DIFF
--- a/configs/autobacklog.example.yaml
+++ b/configs/autobacklog.example.yaml
@@ -32,6 +32,7 @@ claude:
   max_budget_per_call: 10.00         # USD budget cap per CLI invocation
   max_budget_total: 100.00           # USD total budget across all invocations
   timeout: "10m"                     # timeout per invocation
+  # dangerously_skip_permissions: false  # pass --dangerously-skip-permissions to Claude CLI (disabled by default)
 
 # -----------------------------------------------------------------------------
 # Backlog Management

--- a/internal/claude/claude.go
+++ b/internal/claude/claude.go
@@ -31,6 +31,20 @@ func (c *Client) Budget() *Budget {
 	return c.budget
 }
 
+// buildArgs constructs the CLI arguments for a Claude invocation.
+// If jsonOutput is true, --output-format json is included for structured responses.
+func (c *Client) buildArgs(prompt string, jsonOutput bool) []string {
+	args := []string{"--print"}
+	if jsonOutput {
+		args = append(args, "--output-format", "json")
+	}
+	args = append(args, "--model", c.cfg.Model, "--max-budget-usd", fmt.Sprintf("%.2f", c.cfg.MaxBudgetPerCall))
+	if c.cfg.DangerouslySkipPermissions {
+		args = append(args, "--dangerously-skip-permissions")
+	}
+	return append(args, prompt)
+}
+
 // Run invokes the Claude CLI with the given prompt in the given working directory.
 // Returns the raw output string and any error.
 func (c *Client) Run(ctx context.Context, workDir, prompt string) (string, error) {
@@ -41,14 +55,7 @@ func (c *Client) Run(ctx context.Context, workDir, prompt string) (string, error
 	ctx, cancel := context.WithTimeout(ctx, c.cfg.Timeout)
 	defer cancel()
 
-	args := []string{
-		"--print",
-		"--output-format", "json",
-		"--model", c.cfg.Model,
-		"--dangerously-skip-permissions",
-		"--max-budget-usd", fmt.Sprintf("%.2f", c.cfg.MaxBudgetPerCall),
-		prompt,
-	}
+	args := c.buildArgs(prompt, true)
 
 	c.log.Info("invoking claude", "model", c.cfg.Model, "work_dir", workDir, "budget_remaining", fmt.Sprintf("$%.2f", c.budget.Remaining()))
 
@@ -92,13 +99,7 @@ func (c *Client) RunPrint(ctx context.Context, workDir, prompt string) (string, 
 	ctx, cancel := context.WithTimeout(ctx, c.cfg.Timeout)
 	defer cancel()
 
-	args := []string{
-		"--print",
-		"--model", c.cfg.Model,
-		"--dangerously-skip-permissions",
-		"--max-budget-usd", fmt.Sprintf("%.2f", c.cfg.MaxBudgetPerCall),
-		prompt,
-	}
+	args := c.buildArgs(prompt, false)
 
 	c.log.Info("invoking claude (print mode)", "model", c.cfg.Model, "work_dir", workDir)
 

--- a/internal/claude/claude_test.go
+++ b/internal/claude/claude_test.go
@@ -1,0 +1,76 @@
+package claude
+
+import (
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/jamesreagan/autobacklog/internal/config"
+)
+
+func newTestClient(skipPerms bool) *Client {
+	cfg := config.ClaudeConfig{
+		Binary:                     "claude",
+		Model:                      "sonnet",
+		MaxBudgetPerCall:           5.0,
+		MaxBudgetTotal:             50.0,
+		Timeout:                    10 * time.Minute,
+		DangerouslySkipPermissions: skipPerms,
+	}
+	return NewClient(cfg, slog.Default())
+}
+
+func TestBuildArgs_SkipPermissionsDisabled(t *testing.T) {
+	c := newTestClient(false)
+	args := c.buildArgs("do something", true)
+	for _, arg := range args {
+		if arg == "--dangerously-skip-permissions" {
+			t.Error("--dangerously-skip-permissions should not be present when DangerouslySkipPermissions=false")
+		}
+	}
+}
+
+func TestBuildArgs_SkipPermissionsEnabled(t *testing.T) {
+	c := newTestClient(true)
+	args := c.buildArgs("do something", true)
+	found := false
+	for _, arg := range args {
+		if arg == "--dangerously-skip-permissions" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("--dangerously-skip-permissions should be present when DangerouslySkipPermissions=true")
+	}
+}
+
+func TestBuildArgs_JSONOutputIncluded(t *testing.T) {
+	c := newTestClient(false)
+	args := c.buildArgs("prompt", true)
+	for i, arg := range args {
+		if arg == "--output-format" && i+1 < len(args) && args[i+1] == "json" {
+			return
+		}
+	}
+	t.Error("--output-format json should be present when jsonOutput=true")
+}
+
+func TestBuildArgs_JSONOutputExcluded(t *testing.T) {
+	c := newTestClient(false)
+	args := c.buildArgs("prompt", false)
+	for _, arg := range args {
+		if arg == "--output-format" {
+			t.Error("--output-format should not be present when jsonOutput=false")
+		}
+	}
+}
+
+func TestBuildArgs_PromptIsLast(t *testing.T) {
+	c := newTestClient(false)
+	prompt := "my test prompt"
+	args := c.buildArgs(prompt, true)
+	if len(args) == 0 || args[len(args)-1] != prompt {
+		t.Errorf("prompt should be the last argument, got %v", args)
+	}
+}

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -28,11 +28,12 @@ type GitHubConfig struct {
 }
 
 type ClaudeConfig struct {
-	Binary           string        `yaml:"binary"`
-	Model            string        `yaml:"model"`
-	MaxBudgetPerCall float64       `yaml:"max_budget_per_call"`
-	MaxBudgetTotal   float64       `yaml:"max_budget_total"`
-	Timeout          time.Duration `yaml:"timeout"`
+	Binary                    string        `yaml:"binary"`
+	Model                     string        `yaml:"model"`
+	MaxBudgetPerCall          float64       `yaml:"max_budget_per_call"`
+	MaxBudgetTotal            float64       `yaml:"max_budget_total"`
+	Timeout                   time.Duration `yaml:"timeout"`
+	DangerouslySkipPermissions bool         `yaml:"dangerously_skip_permissions"`
 }
 
 type BacklogConfig struct {


### PR DESCRIPTION
## Summary

Both Run() and RunPrint() unconditionally pass --dangerously-skip-permissions to the Claude CLI. This disables all safety permission checks when Claude operates on the cloned repository. An adversarial review finding could cause Claude to make destructive changes (delete files, exfiltrate secrets, modify CI/CD config) without any guardrails. This flag should at minimum be configurable, and preferably should not be used by default.

## Category

security

## Test Results

```
ok  	github.com/jamesreagan/autobacklog/internal/app	0.262s
ok  	github.com/jamesreagan/autobacklog/internal/backlog	0.897s
ok  	github.com/jamesreagan/autobacklog/internal/claude	0.646s
?   	github.com/jamesreagan/autobacklog/internal/cli	[no test files]
ok  	github.com/jamesreagan/autobacklog/internal/config	1.082s
ok  	github.com/jamesreagan/autobacklog/internal/git	1.244s
?   	github.com/jamesreagan/autobacklog/internal/github	[no test files]
?   	github.com/jamesreagan/autobacklog/internal/logging	[no test files]
ok  	github.com/jamesreagan/autobacklog/internal/notify	1.424s
ok  	github.com/jamesreagan/autobacklog/internal/runner	0.548s

```

---
*Created automatically by [autobacklog](https://github.com/jamesreagan/autobacklog)*
