### PR TITLE
[autobacklog] store.Update errors silently ignored throughout implementItem

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -208,7 +208,9 @@ func (a *App) implementItem(ctx context.Context, item *backlog.Item, stats *Cycl
 	// Mark as in progress
 	item.Status = backlog.StatusInProgress
 	item.Attempts++
-	a.store.Update(ctx, item)
+	if err := a.store.Update(ctx, item); err != nil {
+		return fmt.Errorf("updating item status to in_progress: %w", err)
+	}
 
 	// Check budget
 	if !a.claude.Budget().CanSpend(a.cfg.Claude.MaxBudgetPerCall) {
@@ -241,7 +243,9 @@ func (a *App) implementItem(ctx context.Context, item *backlog.Item, stats *Cycl
 		a.log.Warn("claude made no changes", "title", item.Title)
 		a.repo.CheckoutBranch(ctx, a.cfg.Repo.Branch)
 		item.Status = backlog.StatusSkipped
-		a.store.Update(ctx, item)
+		if err := a.store.Update(ctx, item); err != nil {
+			return fmt.Errorf("updating item status to skipped: %w", err)
+		}
 		return nil
 	}
 
@@ -251,7 +255,9 @@ func (a *App) implementItem(ctx context.Context, item *backlog.Item, stats *Cycl
 		a.repo.RevertToClean(ctx)
 		a.repo.CheckoutBranch(ctx, a.cfg.Repo.Branch)
 		item.Status = backlog.StatusFailed
-		a.store.Update(ctx, item)
+		if updateErr := a.store.Update(ctx, item); updateErr != nil {
+			a.log.Error("failed to update item status to failed", "title", item.Title, "error", updateErr)
+		}
 		a.notifier.Send(notify.StuckNotification(item.Title, item.FilePath, item.Attempts, err.Error()))
 		return err
 	}
@@ -281,7 +287,9 @@ func (a *App) implementItem(ctx context.Context, item *backlog.Item, stats *Cycl
 
 	item.Status = backlog.StatusDone
 	item.PRLink = prURL
-	a.store.Update(ctx, item)
+	if err := a.store.Update(ctx, item); err != nil {
+		return fmt.Errorf("updating item status to done: %w", err)
+	}
 	stats.ItemsImplemented++
 	stats.PRsCreated++
 


### PR DESCRIPTION
## Summary

In app.go, a.store.Update(ctx, item) is called five times (lines 211, 244, 254, 284, 291) and the returned error is never checked. If the database update fails, the item's status (in_progress, skipped, failed, done) is never persisted, causing the item to be re-processed on the next cycle and defeating the dedup/status-tracking logic. Fix: check and return/log errors from all store.Update calls.

## Category

bug

## Test Results

```
ok  	github.com/jamesreagan/autobacklog/internal/app	0.445s
ok  	github.com/jamesreagan/autobacklog/internal/backlog	(cached)
ok  	github.com/jamesreagan/autobacklog/internal/claude	0.634s
?   	github.com/jamesreagan/autobacklog/internal/cli	[no test files]
ok  	github.com/jamesreagan/autobacklog/internal/config	0.233s
ok  	github.com/jamesreagan/autobacklog/internal/git	(cached)
?   	github.com/jamesreagan/autobacklog/internal/github	[no test files]
?   	github.com/jamesreagan/autobacklog/internal/logging	[no test files]
ok  	github.com/jamesreagan/autobacklog/internal/notify	(cached)
ok  	github.com/jamesreagan/autobacklog/internal/runner	(cached)

```

---
*Created automatically by [autobacklog](https://github.com/jamesreagan/autobacklog)*
