### PR TITLE
[autobacklog] repo.StageAll error silently ignored before commit

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -257,7 +257,9 @@ func (a *App) implementItem(ctx context.Context, item *backlog.Item, stats *Cycl
 	}
 
 	// Stage and commit
-	a.repo.StageAll(ctx)
+	if err := a.repo.StageAll(ctx); err != nil {
+		return fmt.Errorf("staging changes: %w", err)
+	}
 	commitMsg := fmt.Sprintf("autobacklog: %s\n\n%s", item.Title, item.Description)
 	if err := a.repo.Commit(ctx, commitMsg); err != nil {
 		return fmt.Errorf("committing: %w", err)


### PR DESCRIPTION
## Summary

At line 260, a.repo.StageAll(ctx) is called but its error return is discarded. If staging fails (e.g. git add -A returns non-zero), the subsequent Commit call will either commit nothing or fail with a confusing error message unrelated to the staging failure. Fix: check the error and return it before proceeding to commit.

## Category

bug

## Test Results

```
ok  	github.com/jamesreagan/autobacklog/internal/app	(cached)
ok  	github.com/jamesreagan/autobacklog/internal/backlog	(cached)
ok  	github.com/jamesreagan/autobacklog/internal/claude	(cached)
?   	github.com/jamesreagan/autobacklog/internal/cli	[no test files]
ok  	github.com/jamesreagan/autobacklog/internal/config	(cached)
ok  	github.com/jamesreagan/autobacklog/internal/git	(cached)
?   	github.com/jamesreagan/autobacklog/internal/github	[no test files]
?   	github.com/jamesreagan/autobacklog/internal/logging	[no test files]
ok  	github.com/jamesreagan/autobacklog/internal/notify	(cached)
ok  	github.com/jamesreagan/autobacklog/internal/runner	(cached)

```

---
*Created automatically by [autobacklog](https://github.com/jamesreagan/autobacklog)*
