### PR TITLE
[autobacklog] repo.CheckoutBranch errors silently ignored on failure paths

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -228,7 +228,9 @@ func (a *App) implementItem(ctx context.Context, item *backlog.Item, stats *Cycl
 	prompt := claude.ImplementPrompt(item)
 	_, err = a.claude.RunPrint(ctx, a.repo.WorkDir(), prompt)
 	if err != nil {
-		a.repo.CheckoutBranch(ctx, a.cfg.Repo.Branch)
+		if coErr := a.repo.CheckoutBranch(ctx, a.cfg.Repo.Branch); coErr != nil {
+			a.log.Error("failed to checkout main branch after implement error", "branch", a.cfg.Repo.Branch, "error", coErr)
+		}
 		return fmt.Errorf("claude implement: %w", err)
 	}
 
@@ -239,7 +241,9 @@ func (a *App) implementItem(ctx context.Context, item *backlog.Item, stats *Cycl
 	}
 	if !hasChanges {
 		a.log.Warn("claude made no changes", "title", item.Title)
-		a.repo.CheckoutBranch(ctx, a.cfg.Repo.Branch)
+		if err := a.repo.CheckoutBranch(ctx, a.cfg.Repo.Branch); err != nil {
+			return fmt.Errorf("checkout main branch after no changes: %w", err)
+		}
 		item.Status = backlog.StatusSkipped
 		a.store.Update(ctx, item)
 		return nil
@@ -249,7 +253,9 @@ func (a *App) implementItem(ctx context.Context, item *backlog.Item, stats *Cycl
 	testResult, err := a.runTestsWithRetry(ctx, item)
 	if err != nil {
 		a.repo.RevertToClean(ctx)
-		a.repo.CheckoutBranch(ctx, a.cfg.Repo.Branch)
+		if coErr := a.repo.CheckoutBranch(ctx, a.cfg.Repo.Branch); coErr != nil {
+			a.log.Error("failed to checkout main branch after test failure", "branch", a.cfg.Repo.Branch, "error", coErr)
+		}
 		item.Status = backlog.StatusFailed
 		a.store.Update(ctx, item)
 		a.notifier.Send(notify.StuckNotification(item.Title, item.FilePath, item.Attempts, err.Error()))
@@ -288,7 +294,9 @@ func (a *App) implementItem(ctx context.Context, item *backlog.Item, stats *Cycl
 	a.notifier.Send(notify.PRCreatedNotification(item.Title, prURL, item.Description))
 
 	// Return to main branch for next item
-	a.repo.CheckoutBranch(ctx, a.cfg.Repo.Branch)
+	if err := a.repo.CheckoutBranch(ctx, a.cfg.Repo.Branch); err != nil {
+		return fmt.Errorf("checkout main branch after PR: %w", err)
+	}
 
 	return nil
 }


### PR DESCRIPTION
## Summary

Lines 231, 242, and 291 call a.repo.CheckoutBranch without checking the returned error. If checkout fails mid-implementation (e.g. due to dirty state), subsequent operations (cloning, committing, pushing) proceed on the wrong branch, potentially corrupting the main branch state. Fix: check and handle errors from all CheckoutBranch calls.

## Category

bug

## Test Results

```
ok  	github.com/jamesreagan/autobacklog/internal/app	(cached)
ok  	github.com/jamesreagan/autobacklog/internal/backlog	(cached)
ok  	github.com/jamesreagan/autobacklog/internal/claude	(cached)
?   	github.com/jamesreagan/autobacklog/internal/cli	[no test files]
ok  	github.com/jamesreagan/autobacklog/internal/config	(cached)
ok  	github.com/jamesreagan/autobacklog/internal/git	(cached)
?   	github.com/jamesreagan/autobacklog/internal/github	[no test files]
?   	github.com/jamesreagan/autobacklog/internal/logging	[no test files]
ok  	github.com/jamesreagan/autobacklog/internal/notify	(cached)
ok  	github.com/jamesreagan/autobacklog/internal/runner	(cached)

```

---
*Created automatically by [autobacklog](https://github.com/jamesreagan/autobacklog)*
