### PR TITLE
[autobacklog] PAT leaked in git error messages

### DIFF
--- a/internal/git/clone.go
+++ b/internal/git/clone.go
@@ -94,7 +94,11 @@ func (r *Repo) run(ctx context.Context, dir string, name string, args ...string)
 	cmd.Stderr = &stderr
 
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("%s %s: %w\n%s", name, strings.Join(args, " "), err, stderr.String())
+		argStr := strings.Join(args, " ")
+		if r.pat != "" {
+			argStr = strings.ReplaceAll(argStr, r.pat, "[REDACTED]")
+		}
+		return fmt.Errorf("%s %s: %w\n%s", name, argStr, err, stderr.String())
 	}
 	return nil
 }

--- a/internal/git/clone_test.go
+++ b/internal/git/clone_test.go
@@ -1,0 +1,37 @@
+package git
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+func TestRunRedactsPAT(t *testing.T) {
+	const pat = "ghp_supersecrettoken"
+	r := NewRepo("https://github.com/user/repo.git", "main", t.TempDir(), pat, slog.Default())
+
+	// Run a command that fails and includes the PAT in its arguments.
+	err := r.run(context.Background(), "", "git", "clone", "https://"+pat+"@github.com/user/repo.git", "/nonexistent/path")
+	if err == nil {
+		t.Fatal("expected error from failing command")
+	}
+	if strings.Contains(err.Error(), pat) {
+		t.Errorf("error message contains PAT: %v", err)
+	}
+	if !strings.Contains(err.Error(), "[REDACTED]") {
+		t.Errorf("error message does not contain [REDACTED]: %v", err)
+	}
+}
+
+func TestRunNoPATNoRedaction(t *testing.T) {
+	r := NewRepo("https://github.com/user/repo.git", "main", t.TempDir(), "", slog.Default())
+
+	err := r.run(context.Background(), "", "git", "clone", "https://github.com/user/nonexistent.git", "/nonexistent/path")
+	if err == nil {
+		t.Fatal("expected error from failing command")
+	}
+	if strings.Contains(err.Error(), "[REDACTED]") {
+		t.Errorf("error message unexpectedly contains [REDACTED]: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

In git/clone.go, the `run` helper builds error messages by joining all command arguments with spaces: `fmt.Errorf("%s %s: %w\n%s", name, strings.Join(args, " "), err, stderr.String())`. The `clone` function passes `authenticatedURL()` (which embeds the PAT as `https://<pat>@github.com/...`) as an argument. When the clone fails, the full command including the PAT-embedded URL is included in the error message, which is then logged via `a.log.Error("state failed", ..., "error", err)`. The PAT will appear in structured log output in plaintext. Fix: sanitize the authenticated URL from error messages, or redact the token before constructing the error string.

## Category

security

## Test Results

```
ok  	github.com/jamesreagan/autobacklog/internal/app	(cached)
ok  	github.com/jamesreagan/autobacklog/internal/backlog	(cached)
ok  	github.com/jamesreagan/autobacklog/internal/claude	(cached)
?   	github.com/jamesreagan/autobacklog/internal/cli	[no test files]
ok  	github.com/jamesreagan/autobacklog/internal/config	(cached)
ok  	github.com/jamesreagan/autobacklog/internal/git	0.324s
?   	github.com/jamesreagan/autobacklog/internal/github	[no test files]
?   	github.com/jamesreagan/autobacklog/internal/logging	[no test files]
ok  	github.com/jamesreagan/autobacklog/internal/notify	(cached)
ok  	github.com/jamesreagan/autobacklog/internal/runner	(cached)

```

---
*Created automatically by [autobacklog](https://github.com/jamesreagan/autobacklog)*
