### PR TITLE
Add detailed logging, auto-merge support, and Claude CLI fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ autobacklog
 *.db
 *.exe
 .env
+autobacklog.yaml

--- a/configs/autobacklog.example.yaml
+++ b/configs/autobacklog.example.yaml
@@ -22,6 +22,7 @@ repo:
 github:
   pat: "${GITHUB_TOKEN}"
   # pat_file: "/home/user/.github-pat"
+  auto_merge: false                    # enable to auto-merge PRs after CI passes
 
 # -----------------------------------------------------------------------------
 # Claude Code CLI

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,6 +17,7 @@ Autobacklog is configured via a YAML file. All `${VAR}` references are interpola
 |-------|------|---------|-------------|
 | `pat` | string | | GitHub Personal Access Token (inline) |
 | `pat_file` | string | | Path to file containing PAT |
+| `auto_merge` | bool | `false` | Auto-merge PRs via `gh pr merge --squash --auto` after CI passes |
 
 Falls back to `GITHUB_TOKEN` environment variable if neither is set.
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -59,8 +59,10 @@ func (a *App) RunCycle(ctx context.Context) (*CycleStats, error) {
 	stats := &CycleStats{}
 	state := StateClone
 
+	a.log.Info("starting cycle", "dry_run", a.dryRun, "repo", a.cfg.Repo.URL)
+
 	for state != StateDone {
-		a.log.Info("state transition", "state", state.String())
+		a.log.Info("entering state", "state", state.String(), "action", state.Description())
 
 		var err error
 		switch state {
@@ -75,11 +77,11 @@ func (a *App) RunCycle(ctx context.Context) (*CycleStats, error) {
 		case StateImplement:
 			err = a.doImplement(ctx, stats)
 		case StateTest:
-			// Tests are run per-item inside doImplement
+			a.log.Info("skipping state (tests run during implementation)", "state", state.String())
 			state = state.Next()
 			continue
 		case StatePR:
-			// PRs are created per-item inside doImplement
+			a.log.Info("skipping state (PRs created during implementation)", "state", state.String())
 			state = state.Next()
 			continue
 		case StateDocument:
@@ -93,13 +95,23 @@ func (a *App) RunCycle(ctx context.Context) (*CycleStats, error) {
 			return stats, err
 		}
 
+		a.log.Info("completed state", "state", state.String())
 		state = state.Next()
 	}
 
 	// Clean stale items
+	a.log.Info("cleaning stale backlog items", "stale_days", a.cfg.Backlog.StaleDays)
 	a.manager.CleanStale(ctx, a.cfg.Backlog.StaleDays)
 
 	// Send cycle summary
+	a.log.Info("cycle complete",
+		"items_found", stats.ItemsFound,
+		"items_inserted", stats.ItemsInserted,
+		"items_implemented", stats.ItemsImplemented,
+		"prs_created", stats.PRsCreated,
+		"prs_auto_merged", stats.PRsAutoMerged,
+		"errors", len(stats.Errors),
+	)
 	a.notifier.Send(notify.CycleCompleteNotification(
 		stats.ItemsFound, stats.ItemsImplemented, stats.PRsCreated,
 		a.claude.Budget().String(),
@@ -110,55 +122,70 @@ func (a *App) RunCycle(ctx context.Context) (*CycleStats, error) {
 
 func (a *App) doClone(ctx context.Context) error {
 	if a.dryRun {
-		a.log.Info("[dry-run] would clone/pull repo", "url", a.cfg.Repo.URL)
+		a.log.Info("[dry-run] would clone/pull repo", "url", a.cfg.Repo.URL, "branch", a.cfg.Repo.Branch, "work_dir", a.cfg.Repo.WorkDir)
 		return nil
 	}
+	a.log.Info("cloning or pulling repository", "url", a.cfg.Repo.URL, "branch", a.cfg.Repo.Branch, "work_dir", a.cfg.Repo.WorkDir)
 	return a.repo.CloneOrPull(ctx)
 }
 
 func (a *App) doReview(ctx context.Context, stats *CycleStats) error {
 	if a.dryRun {
-		a.log.Info("[dry-run] would review codebase with Claude")
+		a.log.Info("[dry-run] would review codebase with Claude", "model", a.cfg.Claude.Model, "work_dir", a.cfg.Repo.WorkDir)
 		return nil
 	}
 
+	a.log.Info("invoking Claude to review codebase", "model", a.cfg.Claude.Model, "budget_per_call", a.cfg.Claude.MaxBudgetPerCall)
 	output, err := a.claude.Run(ctx, a.repo.WorkDir(), claude.ReviewPrompt())
 	if err != nil {
 		return fmt.Errorf("review: %w", err)
 	}
 
+	a.log.Info("parsing Claude review output")
 	items, _, err := claude.ParseReviewOutput(output)
 	if err != nil {
 		return fmt.Errorf("parsing review: %w", err)
 	}
 
 	stats.ItemsFound = len(items)
-	// Store items temporarily for ingest phase
+	a.log.Info("review complete", "items_found", len(items))
+	for i, item := range items {
+		a.log.Info("review item", "index", i+1, "title", item.Title, "priority", item.Priority, "category", item.Category)
+	}
 	a.reviewItems = items
 	return nil
 }
 
 func (a *App) doIngest(ctx context.Context, stats *CycleStats) error {
 	if a.dryRun {
-		a.log.Info("[dry-run] would ingest items into backlog")
+		a.log.Info("[dry-run] would ingest items into backlog", "items_to_ingest", len(a.reviewItems))
 		return nil
 	}
 
 	if a.reviewItems == nil {
+		a.log.Info("no review items to ingest")
 		return nil
 	}
 
+	a.log.Info("ingesting review items into backlog", "items_to_ingest", len(a.reviewItems))
 	inserted, err := a.manager.Ingest(ctx, a.reviewItems)
 	if err != nil {
 		return fmt.Errorf("ingest: %w", err)
 	}
 
+	a.log.Info("ingestion complete", "new_items_inserted", inserted, "duplicates_skipped", len(a.reviewItems)-inserted)
 	stats.ItemsInserted = inserted
 	a.reviewItems = nil
 	return nil
 }
 
 func (a *App) doEvaluateThreshold(ctx context.Context, stats *CycleStats) error {
+	a.log.Info("evaluating backlog thresholds",
+		"high_threshold", a.cfg.Backlog.HighThreshold,
+		"medium_threshold", a.cfg.Backlog.MediumThreshold,
+		"low_threshold", a.cfg.Backlog.LowThreshold,
+		"max_per_cycle", a.cfg.Backlog.MaxPerCycle,
+	)
 	result, err := backlog.EvaluateThreshold(ctx, a.store,
 		a.cfg.Backlog.HighThreshold,
 		a.cfg.Backlog.MediumThreshold,
@@ -169,33 +196,43 @@ func (a *App) doEvaluateThreshold(ctx context.Context, stats *CycleStats) error 
 		return fmt.Errorf("threshold evaluation: %w", err)
 	}
 
-	a.log.Info("threshold evaluation", "should_implement", result.ShouldImplement, "reason", result.Reason, "items", len(result.SelectedItems))
+	a.log.Info("threshold evaluation result",
+		"should_implement", result.ShouldImplement,
+		"reason", result.Reason,
+		"selected_items", len(result.SelectedItems),
+	)
 
 	if !result.ShouldImplement {
 		a.selectedItems = nil
 		return nil
 	}
 
+	for i, item := range result.SelectedItems {
+		a.log.Info("selected for implementation", "index", i+1, "title", item.Title, "priority", item.Priority)
+	}
 	a.selectedItems = result.SelectedItems
 	return nil
 }
 
 func (a *App) doImplement(ctx context.Context, stats *CycleStats) error {
 	if a.selectedItems == nil {
-		a.log.Info("no items to implement")
+		a.log.Info("no items selected for implementation, nothing to do")
 		return nil
 	}
 
 	if a.dryRun {
-		a.log.Info("[dry-run] would implement items", "count", len(a.selectedItems))
+		for i, item := range a.selectedItems {
+			a.log.Info("[dry-run] would implement item", "index", i+1, "title", item.Title, "priority", item.Priority, "category", item.Category)
+		}
 		return nil
 	}
 
-	for _, item := range a.selectedItems {
+	a.log.Info("beginning implementation", "items_to_implement", len(a.selectedItems))
+	for i, item := range a.selectedItems {
+		a.log.Info("implementing item", "index", i+1, "of", len(a.selectedItems), "title", item.Title)
 		if err := a.implementItem(ctx, item, stats); err != nil {
 			a.log.Error("failed to implement item", "title", item.Title, "error", err)
 			stats.Errors = append(stats.Errors, err)
-			// Continue with other items
 		}
 	}
 
@@ -203,7 +240,7 @@ func (a *App) doImplement(ctx context.Context, stats *CycleStats) error {
 }
 
 func (a *App) implementItem(ctx context.Context, item *backlog.Item, stats *CycleStats) error {
-	a.log.Info("implementing item", "title", item.Title, "priority", item.Priority)
+	a.log.Info("starting item implementation", "title", item.Title, "priority", item.Priority, "category", item.Category, "attempt", item.Attempts+1)
 
 	// Mark as in progress
 	item.Status = backlog.StatusInProgress
@@ -211,6 +248,7 @@ func (a *App) implementItem(ctx context.Context, item *backlog.Item, stats *Cycl
 	a.store.Update(ctx, item)
 
 	// Check budget
+	a.log.Info("checking budget", "spent", a.claude.Budget().Spent(), "max_per_call", a.cfg.Claude.MaxBudgetPerCall, "max_total", a.cfg.Claude.MaxBudgetTotal)
 	if !a.claude.Budget().CanSpend(a.cfg.Claude.MaxBudgetPerCall) {
 		a.notifier.Send(notify.OutOfTokensNotification(
 			a.claude.Budget().Spent(), a.cfg.Claude.MaxBudgetTotal,
@@ -219,12 +257,15 @@ func (a *App) implementItem(ctx context.Context, item *backlog.Item, stats *Cycl
 	}
 
 	// Create branch
+	a.log.Info("creating feature branch", "prefix", a.cfg.Repo.PRBranchPrefix, "category", item.Category)
 	branchName, err := a.repo.CreateBranch(ctx, a.cfg.Repo.PRBranchPrefix, string(item.Category), item.Title)
 	if err != nil {
 		return fmt.Errorf("creating branch: %w", err)
 	}
+	a.log.Info("created branch", "branch", branchName)
 
 	// Invoke Claude to implement
+	a.log.Info("invoking Claude to implement changes", "title", item.Title)
 	prompt := claude.ImplementPrompt(item)
 	_, err = a.claude.RunPrint(ctx, a.repo.WorkDir(), prompt)
 	if err != nil {
@@ -233,6 +274,7 @@ func (a *App) implementItem(ctx context.Context, item *backlog.Item, stats *Cycl
 	}
 
 	// Check if there are any changes
+	a.log.Info("checking for code changes")
 	hasChanges, err := a.repo.HasChanges(ctx)
 	if err != nil {
 		return fmt.Errorf("checking changes: %w", err)
@@ -246,6 +288,7 @@ func (a *App) implementItem(ctx context.Context, item *backlog.Item, stats *Cycl
 	}
 
 	// Run tests with retry loop
+	a.log.Info("running tests", "max_retries", a.cfg.Testing.MaxRetries)
 	testResult, err := a.runTestsWithRetry(ctx, item)
 	if err != nil {
 		a.repo.RevertToClean(ctx)
@@ -257,6 +300,7 @@ func (a *App) implementItem(ctx context.Context, item *backlog.Item, stats *Cycl
 	}
 
 	// Stage and commit
+	a.log.Info("tests passed, staging and committing changes")
 	a.repo.StageAll(ctx)
 	commitMsg := fmt.Sprintf("autobacklog: %s\n\n%s", item.Title, item.Description)
 	if err := a.repo.Commit(ctx, commitMsg); err != nil {
@@ -264,10 +308,12 @@ func (a *App) implementItem(ctx context.Context, item *backlog.Item, stats *Cycl
 	}
 
 	// Push and create PR
+	a.log.Info("pushing branch to remote", "branch", branchName)
 	if err := a.repo.Push(ctx, branchName); err != nil {
 		return fmt.Errorf("pushing: %w", err)
 	}
 
+	a.log.Info("creating pull request", "title", item.Title, "base", a.cfg.Repo.Branch, "head", branchName)
 	prBody := gh.FormatPRBody(item.Title, item.Description, string(item.Category), testResult)
 	prURL, err := gh.CreatePR(ctx, a.repo.WorkDir(), gh.PRRequest{
 		Title:      fmt.Sprintf("[autobacklog] %s", item.Title),
@@ -279,6 +325,8 @@ func (a *App) implementItem(ctx context.Context, item *backlog.Item, stats *Cycl
 		return fmt.Errorf("creating PR: %w", err)
 	}
 
+	a.log.Info("pull request created", "pr_url", prURL, "title", item.Title)
+
 	item.Status = backlog.StatusDone
 	item.PRLink = prURL
 	a.store.Update(ctx, item)
@@ -287,7 +335,17 @@ func (a *App) implementItem(ctx context.Context, item *backlog.Item, stats *Cycl
 
 	a.notifier.Send(notify.PRCreatedNotification(item.Title, prURL, item.Description))
 
+	// Enable auto-merge if configured
+	if a.cfg.GitHub.AutoMerge {
+		if err := gh.EnableAutoMerge(ctx, a.repo.WorkDir(), prURL, a.log); err != nil {
+			a.log.Warn("auto-merge failed, PR still open for manual merge", "pr", prURL, "error", err)
+		} else {
+			stats.PRsAutoMerged++
+		}
+	}
+
 	// Return to main branch for next item
+	a.log.Info("returning to base branch", "branch", a.cfg.Repo.Branch)
 	a.repo.CheckoutBranch(ctx, a.cfg.Repo.Branch)
 
 	return nil
@@ -304,7 +362,9 @@ func (a *App) runTestsWithRetry(ctx context.Context, item *backlog.Item) (string
 	if a.cfg.Testing.OverrideCommand != "" {
 		command = "sh"
 		args = []string{"-c", a.cfg.Testing.OverrideCommand}
+		a.log.Info("using override test command", "command", a.cfg.Testing.OverrideCommand)
 	} else if a.cfg.Testing.AutoDetect {
+		a.log.Info("auto-detecting test framework", "work_dir", workDir)
 		detected := runner.Detect(workDir, a.log)
 		if detected == nil {
 			a.log.Warn("no test framework detected, skipping tests")
@@ -312,24 +372,28 @@ func (a *App) runTestsWithRetry(ctx context.Context, item *backlog.Item) (string
 		}
 		command = detected.Command
 		args = detected.Args
+		a.log.Info("detected test framework", "command", command, "args", args)
 	} else {
+		a.log.Info("testing disabled, skipping")
 		return "tests disabled", nil
 	}
 
 	var lastOutput string
 	for attempt := 1; attempt <= maxRetries+1; attempt++ {
+		a.log.Info("running test suite", "attempt", attempt, "max_attempts", maxRetries+1)
 		result, err := a.runner.Run(ctx, workDir, command, args)
 		if err != nil {
 			return "", fmt.Errorf("running tests: %w", err)
 		}
 
 		if result.Passed {
+			a.log.Info("tests passed", "attempt", attempt)
 			return result.Output, nil
 		}
 
 		lastOutput = result.Output
 		if attempt <= maxRetries {
-			a.log.Warn("tests failed, attempting fix", "attempt", attempt, "max_retries", maxRetries)
+			a.log.Warn("tests failed, invoking Claude to fix", "attempt", attempt, "max_retries", maxRetries)
 
 			// Ask Claude to fix the tests
 			fixPrompt := claude.FixTestPrompt(result.Output)
@@ -344,7 +408,12 @@ func (a *App) runTestsWithRetry(ctx context.Context, item *backlog.Item) (string
 }
 
 func (a *App) doDocument(ctx context.Context, stats *CycleStats) error {
-	if a.dryRun || stats.ItemsImplemented == 0 {
+	if a.dryRun {
+		a.log.Info("[dry-run] would update documentation", "items_implemented", stats.ItemsImplemented)
+		return nil
+	}
+	if stats.ItemsImplemented == 0 {
+		a.log.Info("no items implemented, skipping documentation update")
 		return nil
 	}
 
@@ -357,9 +426,11 @@ func (a *App) doDocument(ctx context.Context, stats *CycleStats) error {
 	}
 
 	if len(changes) == 0 {
+		a.log.Info("no successful changes to document")
 		return nil
 	}
 
+	a.log.Info("invoking Claude to update documentation", "changes", len(changes))
 	prompt := claude.DocumentPrompt(changes)
 	_, err := a.claude.RunPrint(ctx, a.repo.WorkDir(), prompt)
 	if err != nil {

--- a/internal/app/state.go
+++ b/internal/app/state.go
@@ -42,6 +42,32 @@ func (s State) String() string {
 	}
 }
 
+// Description returns a human-readable description of what this state does.
+func (s State) Description() string {
+	switch s {
+	case StateClone:
+		return "cloning or pulling the target repository"
+	case StateReview:
+		return "reviewing codebase with Claude for improvement opportunities"
+	case StateIngest:
+		return "ingesting review items into the backlog database"
+	case StateEvaluateThreshold:
+		return "evaluating backlog thresholds to decide what to implement"
+	case StateImplement:
+		return "implementing selected backlog items"
+	case StateTest:
+		return "running tests against implemented changes"
+	case StatePR:
+		return "creating pull requests for implemented changes"
+	case StateDocument:
+		return "updating documentation for implemented changes"
+	case StateDone:
+		return "cycle complete"
+	default:
+		return "unknown"
+	}
+}
+
 // Next returns the next state in the sequence.
 func (s State) Next() State {
 	if s >= StateDone {
@@ -56,6 +82,7 @@ type CycleStats struct {
 	ItemsInserted    int
 	ItemsImplemented int
 	PRsCreated       int
+	PRsAutoMerged    int
 	TestFailures     int
 	Errors           []error
 }

--- a/internal/claude/claude.go
+++ b/internal/claude/claude.go
@@ -5,7 +5,9 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"os"
 	"os/exec"
+	"strings"
 
 	"github.com/jamesreagan/autobacklog/internal/config"
 )
@@ -54,6 +56,7 @@ func (c *Client) Run(ctx context.Context, workDir, prompt string) (string, error
 
 	cmd := exec.CommandContext(ctx, c.cfg.Binary, args...)
 	cmd.Dir = workDir
+	cmd.Env = filteredEnv()
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
@@ -64,7 +67,13 @@ func (c *Client) Run(ctx context.Context, workDir, prompt string) (string, error
 		if ctx.Err() != nil {
 			return "", fmt.Errorf("claude timed out after %s: %w", c.cfg.Timeout, ctx.Err())
 		}
-		return "", fmt.Errorf("claude failed: %w\nstderr: %s", err, stderr.String())
+		c.log.Error("claude CLI failed",
+			"exit_error", err,
+			"stderr", stderr.String(),
+			"stdout_len", stdout.Len(),
+			"args", args[:len(args)-1], // log args without the prompt
+		)
+		return "", fmt.Errorf("claude failed: %w\nstderr: %s\nstdout: %s", err, stderr.String(), stdout.String())
 	}
 
 	output := stdout.String()
@@ -104,6 +113,7 @@ func (c *Client) RunPrint(ctx context.Context, workDir, prompt string) (string, 
 
 	cmd := exec.CommandContext(ctx, c.cfg.Binary, args...)
 	cmd.Dir = workDir
+	cmd.Env = filteredEnv()
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
@@ -114,11 +124,29 @@ func (c *Client) RunPrint(ctx context.Context, workDir, prompt string) (string, 
 		if ctx.Err() != nil {
 			return "", fmt.Errorf("claude timed out: %w", ctx.Err())
 		}
-		return "", fmt.Errorf("claude failed: %w\nstderr: %s", err, stderr.String())
+		c.log.Error("claude CLI failed (print mode)",
+			"exit_error", err,
+			"stderr", stderr.String(),
+			"stdout_len", stdout.Len(),
+			"args", args[:len(args)-1],
+		)
+		return "", fmt.Errorf("claude failed: %w\nstderr: %s\nstdout: %s", err, stderr.String(), stdout.String())
 	}
 
 	// Conservative budget recording for non-JSON mode
 	c.budget.Record(c.cfg.MaxBudgetPerCall)
 
 	return stdout.String(), nil
+}
+
+// filteredEnv returns the current environment with the CLAUDECODE variable
+// removed, which prevents the "nested session" check from blocking invocation.
+func filteredEnv() []string {
+	var env []string
+	for _, e := range os.Environ() {
+		if !strings.HasPrefix(e, "CLAUDECODE=") {
+			env = append(env, e)
+		}
+	}
+	return env
 }

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -106,6 +106,7 @@ func runDaemon(cmd *cobra.Command, args []string) error {
 				"items_found", stats.ItemsFound,
 				"items_implemented", stats.ItemsImplemented,
 				"prs_created", stats.PRsCreated,
+				"prs_auto_merged", stats.PRsAutoMerged,
 			)
 		}
 

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -28,6 +28,7 @@ github:
   # Use one of: pat, pat_file, or GITHUB_TOKEN env var
   pat: "${GITHUB_TOKEN}"
   # pat_file: "/path/to/pat-file"
+  auto_merge: false                  # enable to auto-merge PRs after CI passes
 
 claude:
   binary: "claude"

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -95,6 +95,7 @@ func runOnce(cmd *cobra.Command, args []string) error {
 		"items_inserted", stats.ItemsInserted,
 		"items_implemented", stats.ItemsImplemented,
 		"prs_created", stats.PRsCreated,
+		"prs_auto_merged", stats.PRsAutoMerged,
 	)
 
 	return nil

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -23,8 +23,9 @@ type RepoConfig struct {
 }
 
 type GitHubConfig struct {
-	PAT     string `yaml:"pat"`
-	PATFile string `yaml:"pat_file"`
+	PAT       string `yaml:"pat"`
+	PATFile   string `yaml:"pat_file"`
+	AutoMerge bool   `yaml:"auto_merge"`
 }
 
 type ClaudeConfig struct {

--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -46,6 +46,25 @@ func CreatePR(ctx context.Context, workDir string, req PRRequest, log *slog.Logg
 	return prURL, nil
 }
 
+// EnableAutoMerge enables GitHub auto-merge on a PR using `gh pr merge --squash --auto`.
+// This tells GitHub to merge the PR automatically once all required checks pass.
+func EnableAutoMerge(ctx context.Context, workDir string, prURL string, log *slog.Logger) error {
+	log.Info("enabling auto-merge", "pr", prURL)
+
+	cmd := exec.CommandContext(ctx, "gh", "pr", "merge", prURL, "--squash", "--auto")
+	cmd.Dir = workDir
+
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("gh pr merge --auto: %w\n%s", err, stderr.String())
+	}
+
+	log.Info("auto-merge enabled", "pr", prURL)
+	return nil
+}
+
 // FormatPRBody creates a structured PR body from the given fields.
 func FormatPRBody(title, description, category, testResults string) string {
 	var b strings.Builder


### PR DESCRIPTION
## Summary
- Add comprehensive `slog` output across all state machine phases for better observability during cycle runs
- Add `auto_merge` config option to enable `gh pr merge --squash --auto` on created PRs, letting GitHub merge automatically once CI passes
- Filter `CLAUDECODE` env var when invoking Claude CLI subprocess to prevent nested session detection from blocking invocation
- Include stdout in Claude CLI error messages for better debugging
- Add `State.Description()` method for human-readable state explanations
- Add `autobacklog.yaml` to `.gitignore` (user-generated config)

## Test plan
- [x] `go build ./cmd/autobacklog` — builds clean
- [x] `go test ./...` — all 77 tests pass
- [x] `go vet ./...` — no issues
- [ ] CI passes on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)