### PR TITLE
[autobacklog] Branch creation fails silently if branch already exists

### DIFF
--- a/internal/git/branch.go
+++ b/internal/git/branch.go
@@ -3,21 +3,51 @@ package git
 import (
 	"context"
 	"fmt"
+	"os/exec"
 	"regexp"
 	"strings"
 )
 
 var nonAlphaNum = regexp.MustCompile(`[^a-zA-Z0-9-]`)
 
-// CreateBranch creates and checks out a new branch.
+// CreateBranch creates and checks out a branch. If the branch already exists
+// locally (e.g. from a previous cycle that crashed), it is checked out and
+// reset to HEAD so implementation starts from a clean state.
 func (r *Repo) CreateBranch(ctx context.Context, prefix, category, title string) (string, error) {
 	branchName := formatBranchName(prefix, category, title)
-	r.log.Info("creating branch", "name", branchName)
 
+	exists, err := r.branchExists(ctx, branchName)
+	if err != nil {
+		return "", fmt.Errorf("checking branch %s: %w", branchName, err)
+	}
+
+	if exists {
+		r.log.Info("branch already exists, reusing", "name", branchName)
+		if err := r.run(ctx, r.workDir, "git", "checkout", branchName); err != nil {
+			return "", fmt.Errorf("checking out existing branch %s: %w", branchName, err)
+		}
+		if err := r.run(ctx, r.workDir, "git", "reset", "--hard", "HEAD"); err != nil {
+			return "", fmt.Errorf("resetting branch %s: %w", branchName, err)
+		}
+		return branchName, nil
+	}
+
+	r.log.Info("creating branch", "name", branchName)
 	if err := r.run(ctx, r.workDir, "git", "checkout", "-b", branchName); err != nil {
 		return "", fmt.Errorf("creating branch %s: %w", branchName, err)
 	}
 	return branchName, nil
+}
+
+// branchExists reports whether the named branch exists locally.
+func (r *Repo) branchExists(ctx context.Context, name string) (bool, error) {
+	cmd := exec.CommandContext(ctx, "git", "branch", "--list", name)
+	cmd.Dir = r.workDir
+	out, err := cmd.Output()
+	if err != nil {
+		return false, err
+	}
+	return strings.TrimSpace(string(out)) != "", nil
 }
 
 // CheckoutBranch checks out an existing branch.

--- a/internal/git/clone_test.go
+++ b/internal/git/clone_test.go
@@ -196,6 +196,48 @@ func TestCreateBranch(t *testing.T) {
 	}
 }
 
+func TestCreateBranch_AlreadyExists(t *testing.T) {
+	bare := initBareRepo(t)
+	workDir := filepath.Join(t.TempDir(), "clone-target")
+	r := NewRepo(bare, "main", workDir, "", slog.Default())
+
+	ctx := context.Background()
+	if err := r.CloneOrPull(ctx); err != nil {
+		t.Fatalf("CloneOrPull: %v", err)
+	}
+
+	// Create the branch for the first time.
+	branchName, err := r.CreateBranch(ctx, "autobacklog", "bug", "Fix Null Pointer")
+	if err != nil {
+		t.Fatalf("first CreateBranch: %v", err)
+	}
+
+	// Switch back to main to simulate a crash-then-restart scenario.
+	if err := r.CheckoutBranch(ctx, "main"); err != nil {
+		t.Fatalf("CheckoutBranch main: %v", err)
+	}
+
+	// Calling CreateBranch again for the same item should succeed (reuse).
+	got, err := r.CreateBranch(ctx, "autobacklog", "bug", "Fix Null Pointer")
+	if err != nil {
+		t.Fatalf("second CreateBranch (should reuse existing): %v", err)
+	}
+	if got != branchName {
+		t.Errorf("branch name = %q, want %q", got, branchName)
+	}
+
+	// Verify we are now on the branch.
+	cmd := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD")
+	cmd.Dir = workDir
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git rev-parse: %v", err)
+	}
+	if actual := strings.TrimSpace(string(out)); actual != branchName {
+		t.Errorf("HEAD branch = %q, want %q", actual, branchName)
+	}
+}
+
 func TestHasChanges_Integration(t *testing.T) {
 	bare := initBareRepo(t)
 	workDir := filepath.Join(t.TempDir(), "clone-target")


### PR DESCRIPTION
## Summary

CreateBranch() uses git checkout -b which fails if the branch already exists (e.g., from a previous cycle that crashed after branch creation but before pushing/merging). This leaves the item stuck in StatusInProgress with no recovery path. Should check for existing branch and either delete it, reuse it, or generate a unique suffix.

Fixes #11

## Category

bug

## Test Results

```
ok  	github.com/jamesreagan/autobacklog/internal/app	0.948s
ok  	github.com/jamesreagan/autobacklog/internal/backlog	(cached)
ok  	github.com/jamesreagan/autobacklog/internal/claude	(cached)
ok  	github.com/jamesreagan/autobacklog/internal/cli	0.374s
ok  	github.com/jamesreagan/autobacklog/internal/config	(cached)
ok  	github.com/jamesreagan/autobacklog/internal/git	3.560s
ok  	github.com/jamesreagan/autobacklog/internal/github	(cached)
ok  	github.com/jamesreagan/autobacklog/internal/logging	(cached)
ok  	github.com/jamesreagan/autobacklog/internal/notify	(cached)
ok  	github.com/jamesreagan/autobacklog/internal/runner	(cached)

```

---
*Created automatically by [autobacklog](https://github.com/jamesreagan/autobacklog)*
