### PR TITLE
[autobacklog] OverrideCommand executed through sh -c enables shell injection

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -711,8 +711,9 @@ func (a *App) runTestsWithRetry(ctx context.Context, item *backlog.Item) (string
 	var args []string
 
 	if a.cfg.Testing.OverrideCommand != "" {
-		command = "sh"
-		args = []string{"-c", a.cfg.Testing.OverrideCommand}
+		parts := strings.Fields(a.cfg.Testing.OverrideCommand)
+		command = parts[0]
+		args = parts[1:]
 		a.log.Info("using override test command", "command", a.cfg.Testing.OverrideCommand)
 	} else if a.cfg.Testing.AutoDetect {
 		// Cache detection result to avoid redundant filesystem checks per item.

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -73,12 +73,6 @@ func (r *Runner) Run(ctx context.Context, workDir, command string, args []string
 	}, nil
 }
 
-// RunOverride runs a test override command string via sh -c.
-// The command is trusted (sourced from config file); no shell escaping is applied.
-func (r *Runner) RunOverride(ctx context.Context, workDir, command string) (*Result, error) {
-	return r.Run(ctx, workDir, "sh", []string{"-c", command})
-}
-
 // limitedBuffer is a bytes.Buffer that silently discards writes beyond the limit.
 type limitedBuffer struct {
 	buf     bytes.Buffer

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -57,17 +57,3 @@ func TestRunner_RunTimeout(t *testing.T) {
 		t.Error("Passed = true, should fail on timeout")
 	}
 }
-
-func TestRunner_RunOverride(t *testing.T) {
-	r := NewRunner(slog.Default(), 30*time.Second)
-	ctx := context.Background()
-
-	result, err := r.RunOverride(ctx, t.TempDir(), "echo 'hello from override'")
-	if err != nil {
-		t.Fatalf("RunOverride: %v", err)
-	}
-
-	if !result.Passed {
-		t.Error("Passed = false, want true")
-	}
-}


### PR DESCRIPTION
## Summary

When cfg.Testing.OverrideCommand is set, the code passes it verbatim to sh -c (app.go:538-539, runner.go:76). If an attacker can write to the config file they can execute arbitrary shell commands. Additionally, the string is not sanitized in any way. Prefer splitting the command string into tokens and using exec.Command directly, or at minimum document that the config file must be owner-writable only.

Fixes #17

## Category

security

## Test Results

```
?   	github.com/jamesreagan/autobacklog/cmd/autobacklog	[no test files]
ok  	github.com/jamesreagan/autobacklog/internal/app	0.486s
ok  	github.com/jamesreagan/autobacklog/internal/backlog	(cached)
ok  	github.com/jamesreagan/autobacklog/internal/claude	0.527s
ok  	github.com/jamesreagan/autobacklog/internal/cli	0.843s
ok  	github.com/jamesreagan/autobacklog/internal/config	(cached)
ok  	github.com/jamesreagan/autobacklog/internal/git	(cached)
ok  	github.com/jamesreagan/autobacklog/internal/github	(cached)
ok  	github.com/jamesreagan/autobacklog/internal/logging	(cached)
ok  	github.com/jamesreagan/autobacklog/internal/notify	(cached)
ok  	github.com/jamesreagan/autobacklog/internal/runner	1.129s

```

---
*Created automatically by [autobacklog](https://github.com/jamesreagan/autobacklog)*
